### PR TITLE
Optimised the space using only int in deque.

### DIFF
--- a/C++/Algorithms/Greedy/slidingWindowMAximum.cpp
+++ b/C++/Algorithms/Greedy/slidingWindowMAximum.cpp
@@ -2,15 +2,12 @@
 problem statement:-
 You are given an array of integers nums, there is a sliding window of size k which is moving from the very left of the array to the very right. 
 You can only see the k numbers in the window. Each time the sliding window moves right by one position. print the max sliding window.
-
 test case fomrat:-
 N  k  number of array elements window size
 [..] array
-
 test case:- 
 Enter n & k: 8 3
 Enter 8 elements: 1 3 -1 -3 5 3 6 7
-
 Output elements of max sliding window are: 3 3 5 5 6 7 
 */
 
@@ -30,23 +27,27 @@ int main()
     for(int i=0;i<n;i++)
         cin>>nums[i];
 
-    deque<pair<int,int>> dq;   
+    //store the indices of elements in deque.
+    deque<int> dq;
     vector<int> ans;
 
 
     //usuing deque to to keep track of window    
     for(int i=0;i<n;i++)
     {
-        while(!dq.empty() && dq.back().first<nums[i])
+        //if window size is greater than equal to k remove the front.
+        while(!dq.empty() && i-dq.front()>=k)
+            dq.pop_front();
+        
+        //update the maximum element in the monotonous queue.
+        while(!dq.empty() && nums[dq.back()]<nums[i])
             dq.pop_back();
         
-        dq.push_back({nums[i],i+k-1});
+        dq.push_back(i);
             
-        while(!dq.empty() && dq.front().second<i)
-            dq.pop_front();
-            
+        //for each window of size k record the maximum.
         if(i>=k-1)
-            ans.push_back(dq.front().first);
+            ans.push_back(nums[dq.front()]);
     }
 
     cout<<"\nOutput elements of max sliding window are: ";


### PR DESCRIPTION
Added an optimised version of sliding window maximum problem by reducing the space - instead of using deque<pair<int, int>> use deque<int> only.